### PR TITLE
Telephony: Don't crash for too long baseband version

### DIFF
--- a/telephony/java/android/telephony/TelephonyManager.java
+++ b/telephony/java/android/telephony/TelephonyManager.java
@@ -5159,6 +5159,12 @@ public class TelephonyManager {
         if (SubscriptionManager.isValidPhoneId(phoneId)) {
             String prop = TelephonyProperties.PROPERTY_BASEBAND_VERSION +
                     ((phoneId == 0) ? "" : Integer.toString(phoneId));
+            if (version != null && version.length() > SystemProperties.PROP_VALUE_MAX) {
+                Log.e(TAG, "setBasebandVersionForPhone(): version string '" + version +
+                        "' too long! (" + version.length() +
+                        " > " + SystemProperties.PROP_VALUE_MAX + ")");
+                version = version.substring(0, SystemProperties.PROP_VALUE_MAX);
+            }
             SystemProperties.set(prop, version);
         }
     }


### PR DESCRIPTION
Add a check and truncate the baseband version when it's longer than
the allowed value for a SystemProperty (currently 91)

Change-Id: I845b331650eb4446aa251e48d7594ecb10146d54
Reference: BugDumps 13-20161216-22 L#22
(cherry picked from commit bacaf11977c5ef8d6ba7434ec03886e83ca738f9)